### PR TITLE
Add: allow multiple convert type.

### DIFF
--- a/examples/multiple_convert.rs
+++ b/examples/multiple_convert.rs
@@ -1,0 +1,56 @@
+use struct_convert::Convert;
+
+#[derive(Debug, Default, PartialEq)]
+struct B {
+    bid: i64,
+    num: String,
+    name: String,
+}
+
+#[derive(Debug, Default, PartialEq)]
+struct C {
+    bid: i64,
+    num: String,
+    name: String,
+}
+
+#[derive(Debug, Default, Clone, Convert, PartialEq)]
+#[convert(into = "B")]
+#[convert(into = "C")]
+struct A {
+    #[convert_field(rename = "bid")]
+    id: i64,
+
+    #[convert_field(to_string)]
+    num: i64,
+
+    #[convert_field(unwrap)]
+    name: Option<String>,
+}
+
+fn main() {
+    let a = A {
+        id: 2,
+        num: 1,
+        name: Some("Jack".to_string()),
+    };
+    let b: B = a.clone().into();
+    debug_assert_eq!(
+        B {
+            num: "1".to_string(),
+            bid: 2,
+            name: "Jack".to_string(),
+        },
+        b
+    );
+
+    let c: C = a.into();
+    debug_assert_eq!(
+        C {
+            num: "1".to_string(),
+            bid: 2,
+            name: "Jack".to_string(),
+        },
+        c
+    );
+}

--- a/src/auto_from.rs
+++ b/src/auto_from.rs
@@ -3,15 +3,17 @@ use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 
 use syn::{
-    Data, DataStruct, DeriveInput, Expr, Field, Fields, FieldsNamed, GenericArgument, Path, Type,
+    Data, DataStruct, DeriveInput, Field, Fields, FieldsNamed, GenericArgument, Path, Type,
     TypePath,
 };
 
 #[derive(Debug, Default, FromDeriveInput)]
 #[darling(default, attributes(convert))]
 struct MetaOpts {
-    into: String,
-    from: String,
+    #[darling(multiple)]
+    into: Vec<String>,
+    #[darling(multiple)]
+    from: Vec<String>,
 }
 
 #[derive(Debug, Default, FromField)]
@@ -29,20 +31,18 @@ struct FiledOpts {
 struct Fd {
     name: Ident,
     opts: FiledOpts,
-    ty: Type,
     optional: bool,
 }
 /// 把一个 Field 转换成 Fd
 impl From<Field> for Fd {
     fn from(f: Field) -> Self {
-        let (optional, ty) = get_option_inner(&f.ty);
+        let (optional, _) = get_option_inner(&f.ty);
         let opts = FiledOpts::from_field(&f).unwrap_or_default();
         Self {
             // 此时，我们拿到的是 NamedFields，所以 ident 必然存在
             name: f.ident.unwrap(),
             optional,
             opts,
-            ty: ty.to_owned(),
         }
     }
 }
@@ -59,42 +59,45 @@ impl DeriveIntoContext {
         let is_from = !self.attrs.from.is_empty();
 
         if is_from {
-            let struct_name = Ident::new(&format!("{}", name), name.span());
-            let source_name = Ident::new(&format!("{}", self.attrs.from), name.span());
+            TokenStream::from_iter(self.attrs.from.iter().map(|from| {
+                let struct_name = Ident::new(&format!("{}", name), name.span());
+                let source_name = Ident::new(&format!("{}", from), name.span());
 
-            let assigns = self.gen_from_assigns();
+                let assigns = self.gen_from_assigns();
 
-            quote! {
-                impl std::convert::From<#source_name> for #struct_name {
-                    fn from(s: #source_name) -> Self {
-                        #struct_name {
-                        #(#assigns)*
-                        ..#struct_name::default()
+                quote! {
+                        impl std::convert::From<#source_name> for #struct_name {
+                            fn from(s: #source_name) -> Self {
+                                #struct_name {
+                                #(#assigns)*
+                                ..#struct_name::default()
+                            }
                         }
                     }
                 }
-            }
-        }else {
-            let struct_name = Ident::new(&format!("{}", name), name.span());
-            let target_name = Ident::new(&format!("{}", self.attrs.into), name.span());
+            }))
+        } else {
+            TokenStream::from_iter(self.attrs.into.iter().map(|into| {
+                let struct_name = Ident::new(&format!("{}", name), name.span());
+                let target_name = Ident::new(&format!("{}", into), name.span());
 
-            let assigns = self.gen_into_assigns();
+                let assigns = self.gen_into_assigns();
 
-            quote! {
-                impl std::convert::From<#struct_name> for #target_name {
-                    fn from(s: #struct_name) -> Self {
-                        #target_name {
-                        #(#assigns)*
-                        ..#target_name::default()
+                quote! {
+                    impl std::convert::From<#struct_name> for #target_name {
+                        fn from(s: #struct_name) -> Self {
+                            #target_name {
+                                #(#assigns)*
+                                ..#target_name::default()
+                            }
                         }
                     }
                 }
-            }
+            }))
         }
-
     }
 
-        fn gen_from_assigns(&self) -> Vec<TokenStream> {
+    fn gen_from_assigns(&self) -> Vec<TokenStream> {
         self.fields
             .iter()
             .map(
@@ -111,8 +114,8 @@ impl DeriveIntoContext {
                     };
 
                     if !opts.custom_fn.is_empty() {
-                        let custom =  Ident::new(&opts.custom_fn.as_str(), name.span());
-                        return quote!{
+                        let custom = Ident::new(&opts.custom_fn.as_str(), name.span());
+                        return quote! {
                             #name: #custom(&s),
                         };
                     }
@@ -161,8 +164,8 @@ impl DeriveIntoContext {
                     };
 
                     if !opts.custom_fn.is_empty() {
-                        let custom =  Ident::new(&opts.custom_fn.as_str(), name.span());
-                        return quote!{
+                        let custom = Ident::new(&opts.custom_fn.as_str(), name.span());
+                        return quote! {
                             #target_name: #custom(&s),
                         };
                     }


### PR DESCRIPTION
# Allow multiple convert type

In real products, there are situations like this where multiple conversion types are needed.

```rs
#[derive(Debug, Default, Convert)]
#[convert(from = "PostgresUserRow")]
#[convert(from = "RedisUserItem")]
struct User {
    ...
}
```

I added the ability to convert multiple types with a simple extension.