### PR TITLE
Fix whitespaces

### DIFF
--- a/examples/scoped.rs
+++ b/examples/scoped.rs
@@ -1,0 +1,121 @@
+pub mod b {
+  use struct_convert::Convert;
+  #[derive(Debug, PartialEq)]
+  pub struct B {
+    pub bid: i64,
+    pub num: String,
+    pub name: String,
+  }
+}
+
+
+pub mod a1 {
+  use struct_convert::Convert;
+  #[derive(Debug, Convert, PartialEq)]
+  #[convert(into = "crate::b::B")]
+  pub struct A {
+    #[convert_field(into="crate::b::B", rename = "bid")]
+    pub id: i64,
+
+    #[convert_field(to_string)]
+    pub num: i64,
+
+    #[convert_field(unwrap)]
+    pub name: Option<String>,
+  }
+}
+
+pub mod a2 {
+  use struct_convert::Convert;
+  #[derive(Debug, Convert, PartialEq)]
+  #[convert(into = "crate :: b :: B")]
+  pub struct A {
+    #[convert_field(into="crate :: b :: B", rename = "bid")]
+    pub id: i64,
+
+    #[convert_field(to_string)]
+    pub num: i64,
+
+    #[convert_field(unwrap)]
+    pub name: Option<String>,
+  }
+}
+
+pub mod a3 {
+  use struct_convert::Convert;
+  #[derive(Debug, Convert, PartialEq)]
+  #[convert(into = "  crate::b :: B")]
+  pub struct A {
+    #[convert_field(into="  crate::b :: B", rename = "bid")]
+    pub id: i64,
+
+    #[convert_field(to_string)]
+    pub num: i64,
+
+    #[convert_field(unwrap)]
+    pub name: Option<String>,
+  }
+}
+
+fn main() {
+}
+
+#[test]
+fn test_sample_a1() {
+  let a = a1::A {
+    id: 2,
+    num: 1,
+    name: Some("Jack".to_string()),
+  };
+
+  let bval: b::B = a.into();
+
+  debug_assert_eq!(
+    B {
+      num: "1".to_string(),
+      bid: 2,
+      name: "Jack".to_string(),
+    },
+    b
+  );
+}
+
+#[test]
+fn test_sample_a2() {
+  let a = a2::A {
+    id: 2,
+    num: 1,
+    name: Some("Jack".to_string()),
+  };
+
+  let bval: b::B = a.into();
+
+  debug_assert_eq!(
+    B {
+      num: "1".to_string(),
+      bid: 2,
+      name: "Jack".to_string(),
+    },
+    b
+  );
+}
+
+#[test]
+fn test_sample_a3() {
+  let a = a3::A {
+    id: 2,
+    num: 1,
+    name: Some("Jack".to_string()),
+  };
+
+  let bval: b::B = a.into();
+
+  debug_assert_eq!(
+    B {
+      num: "1".to_string(),
+      bid: 2,
+      name: "Jack".to_string(),
+    },
+    b
+  );
+}

--- a/src/auto_from.rs
+++ b/src/auto_from.rs
@@ -68,12 +68,12 @@ impl Fd {
     fn get_by_name(&self, field_class: FieldClass) -> FiledOpts {
         match field_class.clone() {
             FieldClass::From(name) => {
-                for opt in self.multi_opts.iter().filter(|o| o.from.eq(&name)) {
+                if let Some(opt) = self.multi_opts.iter().find(|o| o.from.split_whitespace().collect::<String>().eq(&name.split_whitespace().collect::<String>())) {
                     return opt.clone();
                 }
             }
             FieldClass::Into(name) => {
-                for opt in self.multi_opts.iter().filter(|o| o.into.eq(&name)) {
+                if let Some(opt) = self.multi_opts.iter().find(|o| o.into.split_whitespace().collect::<String>().eq(&name.split_whitespace().collect::<String>())) {
                     return opt.clone();
                 }
             }


### PR DESCRIPTION
Before the fix: 
```
  #[convert_field(into="a  ::  B")]  // Was only accepted
  #[convert_field(into="a::B")]  // Was ignored
```

