### PR TITLE
fix partial move issue when using a custom_fn and moving converters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ proc-macro2 = "1" # proc-macro 的封装
 quote = "1" # 用于生成代码的 TokenStream
 syn = { version = "1", features = ["extra-traits"] } # 用于解析 TokenStream，使用 extra-traits 可以用于 Debug
 darling = "0.14.1"
+itertools = "0.11.0"
 
 derivative = "2.2.0"
 time = "0.3.20"

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -27,7 +27,6 @@ struct D {
 #[derive(Debug, Convert, PartialEq)]
 #[convert(from = "D")]
 struct E {
-    // #[convert_field(unwrap)]
     str: String,
     #[convert_field(rename = "bid", custom_fn = "to_point_from_d")]
     point: Point

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -19,6 +19,21 @@ struct C {
     point: Point,
 }
 
+struct D {
+    str: String,
+    bid: i64,
+}
+
+#[derive(Debug, Convert, PartialEq)]
+#[convert(from = "D")]
+struct E {
+    // #[convert_field(unwrap)]
+    str: String,
+    #[convert_field(rename = "bid", custom_fn = "to_point_from_d")]
+    point: Point
+
+}
+
 #[derive(Debug,  PartialEq)]
 struct Point(i64, i64);
 
@@ -29,6 +44,11 @@ fn str_to_i64(a: &A) -> i64 {
 fn to_point(b: &B) -> Point {
   Point(b.bid, b.bid)
 }
+
+fn to_point_from_d(d: &D) -> Point {
+    Point(d.bid, d.bid)
+}
+
 
 fn main() {
 
@@ -41,4 +61,8 @@ fn test_custom() {
     debug_assert_eq!(B { bid: 4 }, b);
     let c: C = b.into();
     debug_assert_eq!(C { point: Point(4, 4) }, c);
+
+    let d = D { str: "str".into(), bid: 42 };
+    let e: E = d.into();
+    debug_assert_eq!(E { str: "str".into(), point: Point(42, 42) }, e);
 }

--- a/src/auto_from.rs
+++ b/src/auto_from.rs
@@ -1,4 +1,5 @@
 use darling::{FromAttributes, FromDeriveInput, ToTokens};
+use itertools::Itertools;
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 
@@ -118,8 +119,6 @@ impl DeriveIntoContext {
                 let source_name = from;
                 let assigns = self.gen_from_assigns(from.to_token_stream().to_string());
 
-
-
                 let default_code = if self.attrs.default {
                     quote! {..#struct_name::default()}
                 } else {
@@ -177,6 +176,7 @@ impl DeriveIntoContext {
         self.fields
             .clone()
             .into_iter()
+            .sorted_by_key(|fd| fd.get_by_name(FieldClass::From(struct_name.clone())).unwrap_or(fd.default_opts.clone()).custom_fn.is_empty())
             .map(|fd| {
                 let Fd {
                     name,
@@ -345,7 +345,6 @@ impl From<DeriveInput> for DeriveIntoContext {
         };
 
         let fds = fields.into_iter().map(Fd::from).collect();
-
         Self {
             name,
             fields: fds,


### PR DESCRIPTION
Encountered a partial move compilation issue if used a non-copy field along with a custom_fn. This fixes it by rearranging the generated code such that any fields with custom_fns are generated first, and adds a test.

