### PR TITLE
feat: improve custom_fn: allow access to current field from dot

### DIFF
--- a/examples/custom_expression.rs
+++ b/examples/custom_expression.rs
@@ -24,12 +24,29 @@ struct C {
     #[convert_field(custom_fn = "Object::new_with_name(&this.id)")]
     obj: Object,
 }
+// or
+#[derive(Debug, Convert, PartialEq)]
+#[convert(into = "C")]
+struct E {
+    id: String,
+    // Use `.` to access to the current field
+    #[convert_field(custom_fn = "Object::new_with_name(&.name)")]
+    obj: Object,
+}
 
 #[derive(Debug, Convert, PartialEq)]
 #[convert(into = "A")]
 struct D {
     // Use `this` to access to the current instance of the structure
     #[convert_field(custom_fn = "this.id.hex()")]
+    id: Uuuuuid,
+}
+// or
+#[derive(Debug, Convert, PartialEq)]
+#[convert(into = "A")]
+struct F {
+    // Use `.` to access to the current field
+    #[convert_field(custom_fn = ".hex()")]
     id: Uuuuuid,
 }
 


### PR DESCRIPTION
Improved access to the current field for `custom_fn`. Now instead of `custom_fn = "this.current_field.some_fn()"` you can just write `custom_fn = ".some_fn()"`.

Complex expressions are also supported, for example, `custom_fn = "if .is_empty() { .. } else { .. }"`